### PR TITLE
Allow to set a path for the project, needed when working with relative paths and a config.rb file

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,11 @@ pip install git+https://github.com/mila-labs/django-pipeline-compass.git
 # settings.py
 
 PIPELINE_COMPASS_BINARY = '/usr/local/bin/compass'   # default: '/usr/bin/env compass'
-PIPELINE_COMPASS_ARGUMENTS = '-c path/to/config.rb'  # default: ''
+PIPELINE_COMPASS_PROJECT_PATH = '/absolute/path/to/project/'    # default: ''
+PIPELINE_COMPASS_ARGUMENTS = '-c /absolute/path/to/project/config.rb'  # default: ''
 
 PIPELINE_COMPILERS = (
   'pipeline_compass.compass.CompassCompiler',
 )
 ```
+

--- a/pipeline_compass/compass.py
+++ b/pipeline_compass/compass.py
@@ -10,11 +10,13 @@ class CompassCompiler(SubProcessCompiler):
         return filename.endswith(('.scss', '.sass'))
 
     def compile_file(self, infile, outfile, outdated=False, force=False):
-        command = "%s compile --boring --sass-dir=%s --css-dir=%s %s %s" % (
+        command = "%s compile %s --boring --sass-dir=%s --css-dir=%s %s %s" % (
             getattr(settings, 'PIPELINE_COMPASS_BINARY', '/usr/bin/env compass'),
+            getattr(settings, 'PIPELINE_COMPASS_PROJECT_PATH', ''),
             dirname(infile),
             dirname(outfile),
             getattr(settings, 'PIPELINE_COMPASS_ARGUMENTS', ''),
             infile
         )
         return self.execute_command(command, cwd=dirname(infile))
+

--- a/pipeline_compass/compass.py
+++ b/pipeline_compass/compass.py
@@ -10,6 +10,9 @@ class CompassCompiler(SubProcessCompiler):
         return filename.endswith(('.scss', '.sass'))
 
     def compile_file(self, infile, outfile, outdated=False, force=False):
+        if not outdated and not force:
+            return  # No need to recompiled file
+
         command = "%s compile %s --boring --sass-dir=%s --css-dir=%s %s %s" % (
             getattr(settings, 'PIPELINE_COMPASS_BINARY', '/usr/bin/env compass'),
             getattr(settings, 'PIPELINE_COMPASS_PROJECT_PATH', ''),


### PR DESCRIPTION
Also take into account not to regenerate the files each time they are requested, only generate them if they changed.