### PR TITLE
Support newer django-pipeline.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,14 +22,16 @@ Installation
 Usage
 -----
 
+COMPASS_BINARY and COMPASS_ARGUMENTS can be either a string or a list/tuple.
+
 .. code-block:: python
 
     # settings.py
 
-    PIPELINE_COMPASS_BINARY = '/usr/local/bin/compass'   # default: '/usr/bin/env compass'
-    PIPELINE_COMPASS_ARGUMENTS = '-c path/to/config.rb'  # default: ''
+    PIPELINE['COMPASS_BINARY'] = '/usr/local/bin/compass'        # default: ['/usr/bin/env', 'compass']
+    PIPELINE['COMPASS_ARGUMENTS'] = ['-c', 'path/to/config.rb']  # default: []
 
-    PIPELINE_COMPILERS = (
+    PIPELINE['COMPILERS'] = (
       'pipeline_compass.compass.CompassCompiler',
     )
 

--- a/pipeline_compass/compass.py
+++ b/pipeline_compass/compass.py
@@ -10,11 +10,13 @@ class CompassCompiler(SubProcessCompiler):
         return filename.endswith(('.scss', '.sass'))
 
     def compile_file(self, infile, outfile, outdated=False, force=False):
-        command = "%s compile --boring --sass-dir=%s --css-dir=%s %s %s" % (
-            getattr(settings, 'PIPELINE_COMPASS_BINARY', '/usr/bin/env compass'),
-            dirname(infile),
-            dirname(outfile),
-            getattr(settings, 'PIPELINE_COMPASS_ARGUMENTS', ''),
+        conf = getattr(settings, 'PIPELINE', {})
+        command = [
+            conf.get('COMPASS_BINARY', ['/usr/bin/env', 'compass']),
+            "compile", "--boring",
+            "--sass-dir=%s" % dirname(infile),
+            "--css-dir=%s" % dirname(outfile),
+            conf.get('COMPASS_ARGUMENTS', []),
             infile
-        )
+        ]
         return self.execute_command(command, cwd=dirname(infile))


### PR DESCRIPTION
execute_command requires a list of arguments, not a string, since 1.6.1.
Configuration moved to PIPELINE in version 1.5.

I think that should be it, but probably wants more testing!
